### PR TITLE
Revert to previous ecr policy - account number is not required

### DIFF
--- a/api/orchestration_repositories.go
+++ b/api/orchestration_repositories.go
@@ -83,7 +83,7 @@ func (o *ecrOrchestrator) repositoryCreate(ctx context.Context, account, group s
 		return nil, err
 	}
 
-	policy, err := repositoryPolicy(account, req.Groups)
+	policy, err := repositoryPolicy(req.Groups)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (o *ecrOrchestrator) repositoryUpdate(ctx context.Context, account, group, 
 	}
 
 	if req.Groups != nil {
-		policy, err := repositoryPolicy(account, req.Groups)
+		policy, err := repositoryPolicy(req.Groups)
 		if err != nil {
 			return nil, err
 		}

--- a/api/policy.go
+++ b/api/policy.go
@@ -190,9 +190,8 @@ func (s *server) repositoryUserUpdatePolicy() (string, error) {
 
 // repositoryPolicy accepts a list of groups and returns the policy to allow ecr access
 // for resources in the same org/group as well as any passed groups
-func repositoryPolicy(account string, groups []string) (string, error) {
+func repositoryPolicy(groups []string) (string, error) {
 	groupConditions := append([]string{"${aws:ResourceTag/spinup:spaceid}"}, groups...)
-	principal := fmt.Sprintf("arn:aws:iam::%s:root", account)
 
 	log.Debugf("generating policy text from groups %+v", groups)
 
@@ -208,7 +207,7 @@ func repositoryPolicy(account string, groups []string) (string, error) {
 					"ecr:GetDownloadUrlForLayer",
 					"ecr:BatchGetImage",
 				},
-				Principal: iam.Principal{"AWS": iam.Value{principal}},
+				Principal: iam.Principal{"AWS": iam.Value{"*"}},
 				Condition: iam.Condition{
 					"StringEqualsIgnoreCase": iam.ConditionStatement{
 						"aws:PrincipalTag/spinup:org":     []string{"${aws:ResourceTag/spinup:org}"},

--- a/api/policy_test.go
+++ b/api/policy_test.go
@@ -144,8 +144,7 @@ func Test_server_repositoryUserUpdatePolicy(t *testing.T) {
 
 func Test_repositoryPolicy(t *testing.T) {
 	type args struct {
-		account string
-		groups  []string
+		groups []string
 	}
 	tests := []struct {
 		name    string
@@ -156,31 +155,28 @@ func Test_repositoryPolicy(t *testing.T) {
 		{
 			name: "nil",
 			args: args{
-				account: "0123456789",
-				groups:  nil,
+				groups: nil,
 			},
-			want: `{"Version":"2012-10-17","Statement":[{"Sid":"AllowPullImagesFromSpaceAndOrg","Effect":"Allow","Principal":{"AWS":["arn:aws:iam::0123456789:root"]},"Action":["ecr:GetAuthorizationToken","ecr:BatchCheckLayerAvailability","ecr:GetDownloadUrlForLayer","ecr:BatchGetImage"],"Condition":{"StringEqualsIgnoreCase":{"aws:PrincipalTag/spinup:org":["${aws:ResourceTag/spinup:org}"],"aws:PrincipalTag/spinup:spaceid":["${aws:ResourceTag/spinup:spaceid}"]}}}]}`,
+			want: `{"Version":"2012-10-17","Statement":[{"Sid":"AllowPullImagesFromSpaceAndOrg","Effect":"Allow","Principal":{"AWS":["*"]},"Action":["ecr:GetAuthorizationToken","ecr:BatchCheckLayerAvailability","ecr:GetDownloadUrlForLayer","ecr:BatchGetImage"],"Condition":{"StringEqualsIgnoreCase":{"aws:PrincipalTag/spinup:org":["${aws:ResourceTag/spinup:org}"],"aws:PrincipalTag/spinup:spaceid":["${aws:ResourceTag/spinup:spaceid}"]}}}]}`,
 		},
 		{
 			name: "empty list",
 			args: args{
-				account: "0123456789",
-				groups:  []string{},
+				groups: []string{},
 			},
-			want: `{"Version":"2012-10-17","Statement":[{"Sid":"AllowPullImagesFromSpaceAndOrg","Effect":"Allow","Principal":{"AWS":["arn:aws:iam::0123456789:root"]},"Action":["ecr:GetAuthorizationToken","ecr:BatchCheckLayerAvailability","ecr:GetDownloadUrlForLayer","ecr:BatchGetImage"],"Condition":{"StringEqualsIgnoreCase":{"aws:PrincipalTag/spinup:org":["${aws:ResourceTag/spinup:org}"],"aws:PrincipalTag/spinup:spaceid":["${aws:ResourceTag/spinup:spaceid}"]}}}]}`,
+			want: `{"Version":"2012-10-17","Statement":[{"Sid":"AllowPullImagesFromSpaceAndOrg","Effect":"Allow","Principal":{"AWS":["*"]},"Action":["ecr:GetAuthorizationToken","ecr:BatchCheckLayerAvailability","ecr:GetDownloadUrlForLayer","ecr:BatchGetImage"],"Condition":{"StringEqualsIgnoreCase":{"aws:PrincipalTag/spinup:org":["${aws:ResourceTag/spinup:org}"],"aws:PrincipalTag/spinup:spaceid":["${aws:ResourceTag/spinup:spaceid}"]}}}]}`,
 		},
 		{
 			name: "multiple groups",
 			args: args{
-				account: "0123456789",
-				groups:  []string{"foo", "bar", "baz"},
+				groups: []string{"foo", "bar", "baz"},
 			},
-			want: `{"Version":"2012-10-17","Statement":[{"Sid":"AllowPullImagesFromSpaceAndOrg","Effect":"Allow","Principal":{"AWS":["arn:aws:iam::0123456789:root"]},"Action":["ecr:GetAuthorizationToken","ecr:BatchCheckLayerAvailability","ecr:GetDownloadUrlForLayer","ecr:BatchGetImage"],"Condition":{"StringEqualsIgnoreCase":{"aws:PrincipalTag/spinup:org":["${aws:ResourceTag/spinup:org}"],"aws:PrincipalTag/spinup:spaceid":["${aws:ResourceTag/spinup:spaceid}","foo","bar","baz"]}}}]}`,
+			want: `{"Version":"2012-10-17","Statement":[{"Sid":"AllowPullImagesFromSpaceAndOrg","Effect":"Allow","Principal":{"AWS":["*"]},"Action":["ecr:GetAuthorizationToken","ecr:BatchCheckLayerAvailability","ecr:GetDownloadUrlForLayer","ecr:BatchGetImage"],"Condition":{"StringEqualsIgnoreCase":{"aws:PrincipalTag/spinup:org":["${aws:ResourceTag/spinup:org}"],"aws:PrincipalTag/spinup:spaceid":["${aws:ResourceTag/spinup:spaceid}","foo","bar","baz"]}}}]}`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := repositoryPolicy(tt.args.account, tt.args.groups)
+			got, err := repositoryPolicy(tt.args.groups)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("repositoryPolicy() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
After further testing, this caused failure to pull the image.  Removing the account number doesn't seem to allow other accounts to pull images.